### PR TITLE
Added draft pages

### DIFF
--- a/components/cardgrid.js
+++ b/components/cardgrid.js
@@ -5,7 +5,7 @@ export default function CardGrid(props) {
   const { devsFromProps } = props;
   return (
     <>
-      {(devsFromProps||devs).map((dev, idx) => {
+      {(devsFromProps||devs).filter(dev=>!dev.draft).map((dev, idx) => {
         return <Card data={dev}></Card>;
       })}
     </>


### PR DESCRIPTION
`draft: true` in `pages/devs/*mdx` will stop them from rendering in the card grid